### PR TITLE
Do not create temporary files when updating existing ones.

### DIFF
--- a/projects/jupyterhub-singleuser/Dockerfile
+++ b/projects/jupyterhub-singleuser/Dockerfile
@@ -20,7 +20,8 @@ ADD atomiclargefilemanager.py /opt/conda/lib/python3.7/site-packages/notebook/se
 RUN echo "" >> /etc/jupyter/jupyter_notebook_config.py && \
     echo "from notebook.services.contents.atomiclargefilemanager import AtomicLargeFileManager" >> /etc/jupyter/jupyter_notebook_config.py && \
     echo "c.NotebookApp.contents_manager_class = AtomicLargeFileManager" >> /etc/jupyter/jupyter_notebook_config.py && \
-    echo "c.FileCheckpoints.checkpoint_dir = '/home/jovyan/.notebookCheckpoints'" >> /etc/jupyter/jupyter_notebook_config.py
+    echo "c.FileCheckpoints.checkpoint_dir = '/home/jovyan/.notebookCheckpoints'" >> /etc/jupyter/jupyter_notebook_config.py && \
+    echo "c.FileManagerMixin.use_atomic_writing = False" >> /etc/jupyter/jupyter_notebook_config.py
 
 RUN pip install sparqlkernel && \
     jupyter sparqlkernel install


### PR DESCRIPTION
Fixes an issue from https://github.com/fairspace/workspace/pull/1177

According to the jupyter documentation:

>  By default notebooks are saved on disk on a temporary file and then if
>  succefully written, it replaces the old ones. This procedure, namely
>  'atomic_writing', causes some bugs on file system whitout operation order
>  enforcement (like some networked fs). If set to False, the new notebook is
>  written directly on the old one which could fail (eg: full filesystem or quota )