### PR TITLE
Update api version to "v2"

### DIFF
--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
 description: Helm chart to install Jupyter along with a Fairspace workspace
 name: jupyter


### PR DESCRIPTION
To have dependencies in Chart.yaml apparently version 2 of the API is required:
https://helm.sh/docs/topics/charts/#the-apiversion-field

Related linting error in the travis build logs: 

> Chart.yaml: dependencies are not valid in the Chart file with apiVersion 'v1'. They are valid in apiVersion 'v2'