### PR TITLE
Fix Jupyter configuration to use offline token when refreshing the token.

### DIFF
--- a/charts/jupyter/values.yaml
+++ b/charts/jupyter/values.yaml
@@ -53,13 +53,13 @@ jupyterhub:
         auto_login: false
         enable_auth_state: true
         username_key: preferred_username
-        extra_params:
-          scope: offline_access
         client_id:
         client_secret:
         token_url:
         userdata_url:
         logout_redirect_url:
+        scope:
+        - offline_access
     # Requests values are set in Jupyterhub chart.
     resources:
       limits:


### PR DESCRIPTION
The issue with Jupyter was that it was not using the offline token, just a regular refresh token to fetch a new access token. 
As a result it was working only until the originally fetched access token (requested on spawning a jupyter server) was valid.

Steps to reproduce on CI:
1. Go to Jupyter, log in and start a new server
2. After it's launched and Jupyter opens, stop the server manually by selecting "Hub control panel" from this menu:
![Screenshot from 2021-08-30 16-18-23](https://user-images.githubusercontent.com/20908736/131355012-a5d522b2-2eca-4ddb-b899-d3035526448c.png)

3. When the server is stopped, start a new one without logging out -> Error occurs "Spawn failed: Server at http://10.16.9.85:8888/user/organisation-admin-ci/ didn't respond in 30 seconds"

With this fix for scope configuration I can see offline tokens being used in Keycloak and I don't have this issue any more locally.