### PR TITLE
Fix mounting of files for containerd image based nodes.

### DIFF
--- a/projects/jupyterhub-singleuser/start
+++ b/projects/jupyterhub-singleuser/start
@@ -10,6 +10,7 @@ NODE_PATH=/opt/proxy/ node /opt/proxy/app.js &
 # Wait for proxy to start
 sleep 2
 
+sudo ln -s /proc/self/mounts /etc/mtab
 sudo dav_mount "http://localhost:3000/api/webdav" "/home/jovyan/collections" || {
   echo "Error mounting webdav endpoint collections" >&2
   exit 1


### PR DESCRIPTION
Mounting of files with davfs2 does not work on nodes, that use `Container-Optimized OS with containerd` instead of `Container-Optimized OS with Docker`.

The error was: 

> /sbin/mount.davfs: can't access file /etc/mtab: No such file or directory

For the Fairspace project on GCP we use `Container-Optimized OS with Docker` as a base node image.

However, this change needs to be added, because as from GKE node version 1.19, the Docker container runtime is deprecated (containerd should be used instead).

We already have one GCP project that uses containerd instead, for which Jupyter is currently broken because of this issue.