### PR TITLE
Update local development instruction including containerd testing.

### DIFF
--- a/local-development/README.md
+++ b/local-development/README.md
@@ -69,6 +69,17 @@ To start Jupyter Hub:
 ```shell
 # Start minikube
 minikube start
+```
+---
+**NOTE**
+
+To run use **containerd** instead of **docker** as CRI runtime,
+use `--container-runtime=containerd` property for the start command
+and change the `container_runtime` property in `./hub/deploy.sh` to "containerd".
+
+
+---
+```
 minikube addons enable ingress
 
 # Open kubernetes dashboard

--- a/local-development/hub/deploy.sh
+++ b/local-development/hub/deploy.sh
@@ -2,6 +2,7 @@
 
 here=$(realpath $(dirname "${0}"))
 helm_cmd=$(realpath ~/bin/helm3/helm)
+container_runtime="docker"
 
 # Prerequisites:
 # $ minikube start
@@ -10,12 +11,21 @@ helm_cmd=$(realpath ~/bin/helm3/helm)
 host_address=$(minikube ssh grep host.minikube.internal /etc/hosts | cut -f1)
 
 pushd "${here}"
-eval $(minikube docker-env) && \
+
+if [ "$container_runtime" = "docker" ]; then
+  eval $(minikube docker-env)
+fi
+
 (docker build ../../projects/jupyterhub-hub -t jupyterhub-hub-local:latest && docker build ../../projects/jupyterhub-singleuser -t jupyterhub-singleuser-local:latest) || {
   echo "Build failed."
   popd
   exit 1
 }
+
+if [ "$container_runtime" = "containerd" ]; then
+  minikube image load jupyterhub-hub-local:latest --logtostderr
+  minikube image load jupyterhub-singleuser-local:latest --logtostderr
+fi
 
 (kubectl get ns jupyterhub-dev || kubectl create ns jupyterhub-dev) && \
 ((${helm_cmd} repo list | cut -f1 | grep '^jupyterhub') || ${helm_cmd} repo add jupyterhub https://jupyterhub.github.io/helm-chart) && \


### PR DESCRIPTION
If this is useful, something similar can be added to other Fairspace repositories.

Testing with `containerd` helped me reproduce the issue on newer GKE nodes: `Container-Optimised OS with Containerd (cos_containerd)` - mounting of collections with davfs2 did not work there.